### PR TITLE
To adapt datetime format to the web service, padding 0 to day and month.

### DIFF
--- a/CoreInk-Weather.ino
+++ b/CoreInk-Weather.ino
@@ -123,7 +123,10 @@ String createJson(String jsonString){
 }
 
 String dateToString(RTC_Date date) {
-    return String(date.Year)+String("/")+String(date.Month)+String("/")+String(date.Date);
+    char monthStr[5], dayStr[5];
+    sprintf(monthStr, "%02d", date.Month);
+    sprintf(dayStr, "%02d", date.Date);    
+    return String(date.Year)+String("/")+String(monthStr)+String("/")+String(dayStr);
 }
 
 String dateTimeToString(RTC_DateTypeDef RTCdate, RTC_TimeTypeDef RTCtime) {


### PR DESCRIPTION
Webサービス側から返ってくる日付は0で埋められて常に2桁のようなので、日付が一桁の時に比較に失敗してデータが取得できていなかった点を修正してみました。